### PR TITLE
Added description for production environment

### DIFF
--- a/doc/jenkins_ansible_prerequisites.rst
+++ b/doc/jenkins_ansible_prerequisites.rst
@@ -1,6 +1,6 @@
-=============
-Prerequisites
-=============
+====================================================
+Prerequisites for development environment
+====================================================
 
 Before continuing with this tutorial, you need to have the following software installed:
 
@@ -11,3 +11,19 @@ We'll be using Git via its command-line interface, but don't worry if you don't 
 
 .. _Git: http://www.git-scm.com/
 .. _Vagrant: http://vagrantup.com/
+
+====================================================
+Prerequisites for production environment
+====================================================
+
+When you are happy with the development instance you may want to deploy the jenkins to a production server for real work. To do this you will need a linux server with:
+
+- Ansible_
+- Working internet connection (at least until installation is done)
+- Roughly 2Gb memory
+- Enough free disk for your planned project build artifact history
+- Reachable VCS-server for your actual project to continously integrate
+- Preferably a SMTP-server_ for Jenkins notification emails.
+
+.. _Ansible http://www.liquidweb.com/kb/how-to-install-ansible-on-centos-7-via-yum/
+.. _SMTP-server https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol


### PR DESCRIPTION
The tutorial now ends at development point where a local development version of Jenkins is running inside Vagrant box. 

Next we need to document how to deploy the installation to a real production CI-server.

This patch lists some ad hoc requirements that I came up without actually yet doing the deployment. The link for Ansible requirement was directly to CentOS 7 install instructions. 
